### PR TITLE
TAC-228: changed recipe that installs from package to do an upgrade s…

### DIFF
--- a/recipes/nodejs_from_package.rb
+++ b/recipes/nodejs_from_package.rb
@@ -31,5 +31,7 @@ unless node['nodejs']['packages']
 end
 
 node['nodejs']['packages'].each do |node_pkg|
-  package node_pkg
+  package node_pkg do
+    action :upgrade
+  end
 end


### PR DESCRIPTION
…o that we always get the latest version.

Previously it used the default behaviour - install - which, when already installed, does nothing meaning we couldnt upgrade.

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
